### PR TITLE
Ensure mobile audio unlocks on iOS devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,6 @@
 
     <div id="gameOverOverlay"></div>
 
-    <script src="game.js?v=2"></script>
+    <script src="game.js?v=3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- lazily create the Web Audio context and unlock it on the first user interaction so sound works on iOS
- guard squeak playback behind the ensured context so explosions reliably trigger audio on phones
- bump the game.js cache-busting query parameter to v3

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2b0b64a48322977edcfddaf49be3