### PR TITLE
Fix iOS audio unlock and bump cache version

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,6 @@
 
     <div id="gameOverOverlay"></div>
 
-    <script src="game.js?v=2"></script>
+    <script src="game.js?v=3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the Web Audio context is unlocked on first interaction to restore iOS sound effects
- increment the game.js cache-busting query version in the HTML entry point

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd2dc503908322922e5dfc8a1677de