### PR TITLE
Add win screen and stage announcement fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,11 @@
             margin-bottom: 20px;
         }
 
+        #finalMessage {
+            font-size: 24px;
+            margin-bottom: 15px;
+        }
+
         #gameOver p {
             font-size: 24px;
             margin: 10px 0;
@@ -232,7 +237,8 @@
     </div>
 
     <div id="gameOver">
-        <h2>GAME OVER!</h2>
+        <h2 id="finalTitle">GAME OVER!</h2>
+        <p id="finalMessage" style="display: none;"></p>
         <p>Stage reached: <span id="finalStage">1</span></p>
         <p>Total score: <span id="finalScore">0</span></p>
         <p>Correct answers: <span id="finalCorrect">0</span></p>
@@ -242,6 +248,6 @@
 
     <div id="gameOverOverlay"></div>
 
-    <script src="game.js?v=3.1.3"></script>
+    <script src="game.js?v=3.1.4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a dedicated victory overlay after defeating the stage 10 boss, including the final score and restart option
- prevent progression past the final stage by using a stage-count constant and ensure announcements respect the active stage
- enhance the end-screen markup for dynamic messages and bump the synced script version for cache busting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd383187288322b447b6c4b672eb0e