### PR TITLE
Refactor monster roster per stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,6 @@
 
     <div id="gameOverOverlay"></div>
 
-    <script src="game.js?v=3.1.4"></script>
+    <script src="game.js?v=3.2.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add stage-specific monster sets that cycle through five themed monsters per stage
- refactor monster rendering into reusable templates and add a contrasting outline effect
- update stage transitions, restart flow, and asset versioning to use the staged cycle

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd3f64e858832284fe43cb44bf4e15