### PR TITLE
Add monster fireball attacks with shield defense effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,6 @@
 
     <div id="gameOverOverlay"></div>
 
-    <script src="game.js?v=3.2.0"></script>
+    <script src="game.js?v=3.3.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add randomized fireball barrages from monsters and bosses that track the witch
- render glowing projectile trails, shield impact visuals, and a crackling audio cue when blocked
- reset projectile state across transitions and bump the game version/cache bust value

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd57b487a48322918fdaaa2e63e9f4