### PR TITLE
Add English text requirement and update version to 3.3.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 # Agent Instructions
 - With every commit, bump the version number in `game.js` and update the corresponding cache-busting parameter in `index.html`.
 - Keep both values synchronized at all times.
+- Ensure all text content and code comments, including those in `AGENTS.md`, are written in English.

--- a/game.js
+++ b/game.js
@@ -23,7 +23,7 @@
  */
 
 const VERSION_INFO = (() => {
-    const declared = '3.3.3';
+    const declared = '3.3.4';
     let fromQuery = null;
 
     try {
@@ -3591,8 +3591,8 @@ function showVictoryScreen() {
     game.nextFireballTime = null;
     game.witchShield = null;
     showFinalResults({
-        title: 'VYHRÁL JSI!',
-        message: 'Dokončil jsi všech 10 levelů!'
+        title: 'YOU WON!',
+        message: 'You completed all 10 stages!'
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -248,6 +248,6 @@
 
     <div id="gameOverOverlay"></div>
 
-    <script src="game.js?v=3.3.3"></script>
+    <script src="game.js?v=3.3.4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- require all text and code comments to be written in English via AGENTS.md instructions
- translate the victory message to English and bump the declared game version to 3.3.4
- synchronize the cache-busting query parameter in index.html with the new version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd76471cf083229e20b56bbcf21d8e